### PR TITLE
キーボードを閉じられるようにする

### DIFF
--- a/FavoriteHotels/View/Cell/SectionTableViewCell.swift
+++ b/FavoriteHotels/View/Cell/SectionTableViewCell.swift
@@ -15,6 +15,7 @@ class SectionTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         selectionStyle = .none
+        answerTextField.delegate = self
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -25,5 +26,16 @@ class SectionTableViewCell: UITableViewCell {
         didSet {
             titleLabel.text = titleText
         }
+    }
+}
+
+//MARK: - TextFieldDelegate
+extension SectionTableViewCell: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.contentView.endEditing(true)
     }
 }


### PR DESCRIPTION
## 概要
・UITextFieldDelegateを追加
・returnキーとtextField外タップでキーボードを閉じられるようにする

## 補足
該当のカスタムセルの外をタップするとキーボードが閉じないため、今後修正を予定。